### PR TITLE
Docs: Add missing tablenames for Group and Role

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -71,11 +71,15 @@ Defining database models:
 
 
     class Group(db.Model, RestrictionsMixin):
+        __tablename__ = 'groups'
+        
         id = db.Column(db.Integer, primary_key=True)
         name = db.Column(db.String(255), nullable=False, unique=True)
 
 
     class Role(db.Model, AllowancesMixin):
+        __tablename__ = 'roles'
+        
         id = db.Column(db.Integer, primary_key=True)
         name = db.Column(db.String(255), nullable=False, unique=True)
 


### PR DESCRIPTION
Using your example I received the following error

> qlalchemy.exc.NoForeignKeysError: Could not determine join condition between parent/child tables on relationship User.roles - there are no foreign keys linking these tables via secondary table 'user_role'.  Ensure that referencing columns are associated with a ForeignKey or ForeignKeyConstraint, or specify 'primaryjoin' and 'secondaryjoin' expressions.

Adding a tablename as on sqlalchemy website solves this problem
[SQLAlchemy Many to Many table](https://docs.sqlalchemy.org/en/13/orm/basic_relationships.html#many-to-many)