### PR TITLE
Granular permissions

### DIFF
--- a/flask_authorize/__init__.py
+++ b/flask_authorize/__init__.py
@@ -15,6 +15,8 @@ from .mixins import OwnerPermissionsMixin       ## noqa
 from .mixins import GroupPermissionsMixin       ## noqa
 from .mixins import PermissionsMixin            ## noqa
 
+from .mixins import AccessControlPermissionsMixin  ## noqa
+
 from .mixins import default_permissions         ## noqa
 from .mixins import default_allowances          ## noqa
 from .mixins import default_restrictions        ## noqa

--- a/flask_authorize/mixin_generator.py
+++ b/flask_authorize/mixin_generator.py
@@ -1,0 +1,50 @@
+
+from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy.orm import relationship, backref
+
+from sqlalchemy.ext.declarative import declared_attr
+
+from flask_authorize.mixins import PipedList
+
+def generate_association_table(entity_name, resource_name, entity_tablename=None, resource_tablename=None):
+
+    # Make them plural by adding 's' :)
+    if not entity_tablename:
+        entity_tablename = entity_name.lower() + 's'
+    if not resource_tablename:
+        resource_tablename = resource_name.lower() + 's'
+
+    # More names
+    entity_name_lower = entity_name.lower()
+    resource_name_lower = resource_name.lower()
+
+    @declared_attr
+    def left_id(cls):
+        return Column(Integer, ForeignKey(f"{entity_tablename}.id"), primary_key=True)
+    
+    @declared_attr
+    def right_id(cls):
+        return Column(Integer, ForeignKey(f"{resource_tablename}.id"), primary_key=True)
+    
+    @declared_attr
+    def entity_relationship(cls):
+        return relationship(f"{entity_name}", backref=backref(f"special_{resource_tablename}", lazy="dynamic"))
+    
+    @declared_attr
+    def resource_relationship(cls):
+        return relationship(f"{resource_name}", backref=backref(f"special_{entity_tablename}", lazy="dynamic"))
+
+    class PermissionsAssociationMixin:
+        __tablename__ = f"{entity_tablename}_{resource_tablename}_association"
+
+        entity_id = left_id
+        resource_id = right_id
+
+        locals()[f"special_{entity_tablename}"] = entity_relationship
+        locals()[f"special_{resource_tablename}"] = resource_relationship
+
+        permissions = Column(PipedList)
+
+    return PermissionsAssociationMixin
+        
+    

--- a/flask_authorize/mixins.py
+++ b/flask_authorize/mixins.py
@@ -4,6 +4,7 @@
 #
 # ------------------------------------------------
 
+
 # imports
 # -------
 import six
@@ -26,7 +27,6 @@ class JSON(TypeDecorator):
     SQLite, MySQL, and PostgreSQL compatible type
     for json column.
     """
-
     impl = Text
 
     @property
@@ -51,7 +51,6 @@ class PipedList(TypeDecorator):
     separated by pipes '|' when referenced in the
     database.
     """
-
     impl = Text
 
     @property
@@ -59,7 +58,9 @@ class PipedList(TypeDecorator):
         return object
 
     def coerce_compared_value(self, op, value):
-        if op in (operators.like_op, operators.notlike_op, operators.contains_op):
+        if op in (operators.like_op,
+                  operators.notlike_op,
+                  operators.contains_op):
             return Text()
         else:
             return self
@@ -67,13 +68,13 @@ class PipedList(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if not value:
             return None
-        return "|".join(value)
+        return '|'.join(value)
 
     def process_result_value(self, value, dialect):
         try:
             if not value:
                 return []
-            return value.split("|")
+            return value.split('|')
         except (ValueError, TypeError):
             return None
 
@@ -91,13 +92,12 @@ def gather_models():
     global MODELS
 
     from flask import current_app
-
-    if "sqlalchemy" not in current_app.extensions:
+    if 'sqlalchemy' not in current_app.extensions:
         return
-    check = current_app.config["AUTHORIZE_IGNORE_PROPERTY"]
+    check = current_app.config['AUTHORIZE_IGNORE_PROPERTY']
 
     # inspect current models and add to map
-    db = current_app.extensions["sqlalchemy"].db
+    db = current_app.extensions['sqlalchemy'].db
     for cls in db.Model._decl_class_registry.values():
         if isinstance(cls, type) and issubclass(cls, db.Model):
             if hasattr(cls, check) and not getattr(cls, check):
@@ -112,21 +112,21 @@ def table_key(cls):
     configuration included for extension.
     """
     # class name
-    if current_app.config["AUTHORIZE_MODEL_PARSER"] == "class":
+    if current_app.config['AUTHORIZE_MODEL_PARSER'] == 'class':
         return cls.__name__
 
     # lowercase name
-    elif current_app.config["AUTHORIZE_MODEL_PARSER"] == "lower":
+    elif current_app.config['AUTHORIZE_MODEL_PARSER'] == 'lower':
         return cls.__name__.lower()
 
     # snake_case name
-    elif current_app.config["AUTHORIZE_MODEL_PARSER"] == "snake":
-        words = re.findall(r"([A-Z][0-9a-z]+)", cls.__name__)
+    elif current_app.config['AUTHORIZE_MODEL_PARSER'] == 'snake':
+        words = re.findall(r'([A-Z][0-9a-z]+)', cls.__name__)
         if len(words) > 1:
-            return "_".join(map(lambda x: x.lower(), words))
+            return '_'.join(map(lambda x: x.lower(), words))
 
     # table name
-    elif current_app.config["AUTHORIZE_MODEL_PARSER"] == "table":
+    elif current_app.config['AUTHORIZE_MODEL_PARSER'] == 'table':
         mapper = inspect(cls)
         return mapper.tables[0].name
 
@@ -135,11 +135,9 @@ def default_permissions_factory(name):
     """
     Factory for returning default permissions based on name.
     """
-
     def _(cls=None):
         perms = default_permissions(cls)
         return perms.get(name, [])
-
     return _
 
 
@@ -150,7 +148,7 @@ def default_permissions(cls=None):
     is explicitly set.
     """
     if cls is None or cls.__permissions__ is None:
-        return current_app.config["AUTHORIZE_DEFAULT_PERMISSIONS"]
+        return current_app.config['AUTHORIZE_DEFAULT_PERMISSIONS']
     elif isinstance(cls._permissions__, int):
         return parse_permission_set(cls.__permissions__)
     elif isinstance(cls.__permissions__, dict):
@@ -170,7 +168,8 @@ def default_allowances(cls=None):
 
     # configure defaults
     default = {
-        key: current_app.config["AUTHORIZE_DEFAULT_ALLOWANCES"] for key in MODELS
+        key: current_app.config['AUTHORIZE_DEFAULT_ALLOWANCES']
+        for key in MODELS
     }
 
     # if called directly, return the defaults
@@ -198,7 +197,8 @@ def default_restrictions(cls=None):
 
     # configure defaults
     default = {
-        key: current_app.config["AUTHORIZE_DEFAULT_RESTRICTIONS"] for key in MODELS
+        key: current_app.config['AUTHORIZE_DEFAULT_RESTRICTIONS']
+        for key in MODELS
     }
 
     # if called directly, return the defaults
@@ -206,8 +206,11 @@ def default_restrictions(cls=None):
         return default
 
     # if set to fail safe, use that
-    if cls.__restrictions__ == "*" or cls.__restrictions__ is True:
-        return {key: current_app.config["AUTHORIZE_DEFAULT_ACTIONS"] for key in MODELS}
+    if cls.__restrictions__ == '*' or cls.__restrictions__ is True:
+        return {
+            key: current_app.config['AUTHORIZE_DEFAULT_ACTIONS']
+            for key in MODELS
+        }
 
     # overwrite specified allowances
     if isinstance(cls.__restrictions__, dict):
@@ -225,7 +228,7 @@ def permission_list(number):
         return number
 
     ret = []
-    for mask, name in zip([1, 2, 4], ["delete", "read", "update"]):
+    for mask, name in zip([1, 2, 4], ['delete', 'read', 'update']):
         if number & mask:
             ret.append(name)
     return ret
@@ -245,11 +248,11 @@ def parse_permission_set(number):
     # check validity of input
     digits = len(str(number))
     if digits > 3:
-        raise AssertionError("Invalid permissions: {}".format(number))
+        raise AssertionError('Invalid permissions: {}'.format(number))
 
     # gather permissions
     result = {}
-    for digit, check in zip([0, 1, 2], ["other", "group", "owner"]):
+    for digit, check in zip([0, 1, 2], ['other', 'group', 'owner']):
         perm = int(number) // 10 ** digit % 10
         result[check] = permission_list(perm)
     return result
@@ -262,12 +265,11 @@ class BasePermissionsMixin(object):
     Abstract base class for enabling common functionality
     across various optional permission schemes.
     """
-
     __permissions__ = None
 
     @declared_attr
     def other_permissions(cls):
-        return Column(PipedList, default=default_permissions_factory("other"))
+        return Column(PipedList, default=default_permissions_factory('other'))
 
     @classmethod
     def authorized(cls, check):
@@ -299,57 +301,21 @@ class BasePermissionsMixin(object):
                 ))
         """
         from .plugin import CURRENT_USER
-
         current_user = CURRENT_USER()
         clauses = [
             cls.other_permissions.contains(check),
         ]
-        if hasattr(current_user, "id"):
-            if hasattr(cls, "owner_id"):
-                clauses.append(
-                    and_(
-                        current_user.id == cls.owner_id,
-                        cls.owner_permissions.contains(check),
-                    )
-                )
-            if hasattr(cls, "group_id") and hasattr(current_user, "groups"):
-                clauses.append(
-                    and_(
-                        cls.group_id.in_([x.id for x in current_user.groups]),
-                        cls.group_permissions.contains(check),
-                    )
-                )
-
-            # Check user for special permissions
-            if hasattr(current_user, f"special_{cls.__tablename__}"):
-                clauses.append(
-                    cls.id.in_(
-                        [
-                            x.resource_id
-                            for x in getattr(
-                                current_user, f"special_{cls.__tablename__}"
-                            )
-                            if check in x.permissions
-                        ]
-                    )
-                )
-
-            # Check if user is part of a group that has special access
-            if hasattr(cls, "special_groups"):
-                group_list = [
-                    x.special_groups.all()
-                    for x in cls.query.all()
-                    if x.special_groups.all()
-                ]
-                overlapping_groups = [
-                    y.resource_id
-                    for x in group_list
-                    for y in x
-                    if y.entity_id in [n.id for n in current_user.groups]
-                    if check in y.permissions
-                ]
-                clauses.append(cls.id.in_(overlapping_groups))
-
+        if hasattr(current_user, 'id'):
+            if hasattr(cls, 'owner_id'):
+                clauses.append(and_(
+                    current_user.id == cls.owner_id,
+                    cls.owner_permissions.contains(check)
+                ))
+            if hasattr(cls, 'group_id') and hasattr(current_user, 'groups'):
+                clauses.append(and_(
+                    cls.group_id.in_([x.id for x in current_user.groups]),
+                    cls.group_permissions.contains(check)
+                ))
         return or_(*clauses)
 
     @property
@@ -358,8 +324,8 @@ class BasePermissionsMixin(object):
         Proxy for interacting with permissions dictionary.
         """
         result = {}
-        for name in ["owner", "group", "other"]:
-            prop = name + "_permissions"
+        for name in ['owner', 'group', 'other']:
+            prop = name + '_permissions'
             if hasattr(self, prop):
                 result[name] = getattr(self, prop)
         return result
@@ -369,10 +335,10 @@ class BasePermissionsMixin(object):
         """
         Setter for permissions dictionary proxy.
         """
-        for name in ["owner", "group", "other"]:
+        for name in ['owner', 'group', 'other']:
             if name not in value:
                 continue
-            prop = name + "_permissions"
+            prop = name + '_permissions'
             if hasattr(self, prop):
                 setattr(self, prop, value[name])
         return
@@ -381,8 +347,8 @@ class BasePermissionsMixin(object):
         """
         Set permissions explicitly for ACL-enforced content.
         """
-        if "authorize" in current_app.extensions:
-            authorize = current_app.extensions["authorize"]
+        if 'authorize' in current_app.extensions:
+            authorize = current_app.extensions['authorize']
             if not authorize.update(self):
                 raise Unauthorized
 
@@ -403,18 +369,17 @@ class OwnerMixin(object):
     Mixin providing owner-related database properties
     for object, in the context of enforcing permissions.
     """
-
     @declared_attr
     def owner_id(cls):
-        return Column(Integer, ForeignKey("users.id"))
+        return Column(Integer, ForeignKey('users.id'))
 
     @declared_attr
     def owner(cls):
-        return relationship("User")
+        return relationship('User')
 
     @declared_attr
     def owner_permissions(cls):
-        return Column(PipedList, default=default_permissions_factory("owner"))
+        return Column(PipedList, default=default_permissions_factory('owner'))
 
 
 class OwnerPermissionsMixin(BasePermissionsMixin, OwnerMixin):
@@ -426,18 +391,17 @@ class GroupMixin(object):
     Mixin providing group-related database properties
     for object, in the context of enforcing permissions.
     """
-
     @declared_attr
     def group_id(cls):
-        return Column(Integer, ForeignKey("groups.id"))
+        return Column(Integer, ForeignKey('groups.id'))
 
     @declared_attr
     def group(cls):
-        return relationship("Group")
+        return relationship('Group')
 
     @declared_attr
     def group_permissions(cls):
-        return Column(PipedList, default=default_permissions_factory("group"))
+        return Column(PipedList, default=default_permissions_factory('group'))
 
 
 class GroupPermissionsMixin(BasePermissionsMixin, GroupMixin):
@@ -469,7 +433,6 @@ class PermissionsMixin(BasePermissionsMixin, OwnerMixin, GroupMixin):
     Mixin providing owner and group-related database properties
     for object, in the context of enforcing permissions.
     """
-
     pass
 
 
@@ -495,7 +458,6 @@ class RestrictionsMixin(object):
     """
     Mixin providing group or role based access control.
     """
-
     __restrictions__ = dict()
 
     @declared_attr
@@ -518,8 +480,7 @@ class AllowancesMixin(object):
     """
     Mixin providing group or role based access control.
     """
-
-    __allowances__ = "*"
+    __allowances__ = '*'
 
     @declared_attr
     def allowances(cls):
@@ -535,3 +496,46 @@ class AllowancesMixin(object):
         allowances.update(kwargs)
         self.allowances = allowances
         return self
+
+class AccessControlPermissionsMixin(PermissionsMixin):
+    
+    @classmethod
+    def authorized(cls, check):
+        from .plugin import CURRENT_USER
+        current_user = CURRENT_USER()
+
+        ret = super().authorized(check)
+        
+        clauses = []
+
+        # Check user for special permissions
+        if hasattr(current_user, f'special_{cls.__tablename__}'):
+            clauses.append(
+                cls.id.in_(
+                    [
+                        x.resource_id
+                        for x in getattr(
+                            current_user, f'special_{cls.__tablename__}'
+                        )
+                        if check in x.permissions
+                    ]
+                )
+            )
+
+        # Check if user is part of a group that has special access
+        if hasattr(cls, 'special_groups'):
+            group_list = [
+                x.special_groups.all()
+                for x in cls.query.all()
+                if x.special_groups.all()
+            ]
+            overlapping_groups = [
+                y.resource_id
+                for x in group_list
+                for y in x
+                if y.entity_id in [n.id for n in current_user.groups]
+                if check in y.permissions
+            ]
+            clauses.append(cls.id.in_(overlapping_groups))
+
+        return or_(ret, or_(*clauses))

--- a/flask_authorize/mixins.py
+++ b/flask_authorize/mixins.py
@@ -523,7 +523,7 @@ class AccessControlPermissionsMixin(PermissionsMixin):
             )
 
         # Check if user is part of a group that has special access
-        if hasattr(cls, 'special_groups'):
+        if current_user and hasattr(cls, 'special_groups'):
             group_list = [
                 x.special_groups.all()
                 for x in cls.query.all()

--- a/flask_authorize/mixins.py
+++ b/flask_authorize/mixins.py
@@ -4,7 +4,6 @@
 #
 # ------------------------------------------------
 
-
 # imports
 # -------
 import six
@@ -316,6 +315,11 @@ class BasePermissionsMixin(object):
                     cls.group_id.in_([x.id for x in current_user.groups]),
                     cls.group_permissions.contains(check)
                 ))
+
+            if hasattr(current_user, f"special_{cls.__tablename__}"):
+                clauses.append(
+                    cls.id.in_([x.resource_id for x in getattr(current_user, f"special_{cls.__tablename__}") if check in x.permissions])
+                )
         return or_(*clauses)
 
     @property

--- a/flask_authorize/plugin.py
+++ b/flask_authorize/plugin.py
@@ -402,6 +402,21 @@ class Authorizer(object):
                         check = arg.permissions.get('group', [])
                         permitted |= has_permission(operation, check)
 
+            # check special permissions
+            # should probably figure this out instead of cheating.
+            operation = list(operation)[0]
+            
+            if hasattr(arg, "special_users") and CURRENT_USER():
+                for user in arg.special_users.all():
+                    if CURRENT_USER.id == user.id:
+                        permitted |= operation.values() in user.permissions
+
+            if hasattr(arg, "special_groups") and CURRENT_USER():
+                for group in arg.special_groups.all():
+                    if group.entity_id in [x.id for x in CURRENT_USER().groups ]:
+                        
+                        permitted |= operation in group.permissions
+
             if not permitted:
                 return False
 

--- a/flask_authorize/plugin.py
+++ b/flask_authorize/plugin.py
@@ -407,9 +407,9 @@ class Authorizer(object):
             operation = list(operation)[0]
             
             if hasattr(arg, "special_users") and CURRENT_USER():
-                for user in arg.special_users.all():
-                    if CURRENT_USER.id == user.id:
-                        permitted |= operation.values() in user.permissions
+                for assoc in arg.special_users.all():
+                    if CURRENT_USER().id == assoc.entity_id:
+                        permitted |= operation in assoc.permissions
 
             if hasattr(arg, "special_groups") and CURRENT_USER():
                 for group in arg.special_groups.all():

--- a/tests/test_special_permissions.py
+++ b/tests/test_special_permissions.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Testing for access control list authorization.
+#
+# ------------------------------------------------
+
+
+# imports
+# -------
+from sqlalchemy import and_
+from flask import g
+
+from .fixtures import authorize, Paper, PaperFactory, UserPaperAssociation
+
+
+# helpers
+# -------
+def query(name, check):
+    return Paper.query.filter(and_(
+        Paper.name.contains(name),
+        Paper.authorized(check)
+    )).all()
+
+
+# session
+# -------
+class TestSpecialPermissions(object):
+
+    def test_special_read(self, client, special, editor):
+
+        # create user and resource. resource is owned
+        # by another user
+        g.user = editor
+        article = PaperFactory.create(
+            name='Other Delete Open Article',
+            owner=editor,
+            group=editor.groups[0]
+        ).set_permissions('660')
+
+        # Set up association
+        assoc = UserPaperAssociation(entity_id=g.user.id, resource_id=article.id, permissions=['read'])
+
+        # give user read access
+        assoc.paper = article
+        special.special_papers.append(assoc)
+
+        # switch the user
+        g.user = special
+        
+        assert authorize.read(article)
+        assert query(article.name, 'read')
+
+
+    
+
+


### PR DESCRIPTION
Hi @bprinty - I realize you may be working to implement something like this for the next release, but I wanted to make you aware of some work I've done related/get your thoughts. I wanted to be able to give fully granular permissions in some case, like described here (https://wiki.archlinux.org/index.php/Access_Control_Lists). Most of the time owner, group, world, will be sufficient for my app, but sometimes people will want to give access to specific resources to individuals.

I had this as an extension/patch in my app originally, but I thought I'd put it here also.

This was the approach I took:

Having special permissions for a user on a resource requires a table which maps the user to that resource and contains permissions. This would follow the association table pattern in sqlalchemy (https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html#association-object).  This has the downside that a new table must be generated for each resource type (for example if you have `Articles` and `Papers`, if you wanted to be able to give users access to individual items for both, you would need a user association table for each).  I created a function which creates a mixin to create this type of association table (`flaske_authorize/mixin_generator.py`). 

When this association table is created it has a dual primary key which are foreign keys into the entity (users, for example), and the resource (articles, for example). It also populates the entity and resource tables with attributes `special_{entity}` or `special_{resource}` respectively. In other words, you could access the association entry containing users which have been given special permissions on an article using `article.special_users`, or articles to which a user has been given special permissions using `user.special_articles` 

I created a new mixin called `AccessControlPermissionsMixin` which inherits from and adds to `Permissions` mixin which is capable of checking permissions from created association tables. I did add a check to `plugin.py` as well.

There is an example in `tests/test_special_permissions.py`. I'm not sure if it works for everything, I just thought I'd throw this up to get your thoughts!