### PR TITLE
Modified mixins.py and plugins.py to fix ruff linting remarks

### DIFF
--- a/flask_authorize/mixins.py
+++ b/flask_authorize/mixins.py
@@ -146,7 +146,6 @@ def class_registry(cls):
         return dict(cls._sa_registry._class_registry)
     except:
         return dict(cls._decl_class_registry)
-    return
 
 
 def default_permissions_factory(name):

--- a/flask_authorize/plugin.py
+++ b/flask_authorize/plugin.py
@@ -13,7 +13,7 @@ from functools import wraps
 from flask import current_app
 from werkzeug.exceptions import Unauthorized
 
-from .mixins import default_permissions, default_allowances, table_key
+from .mixins import default_allowances, table_key
 
 
 # constants


### PR DESCRIPTION
Hey there, 
Modified a couple of files after passing ruff inside the repo. 

Did not correct the last remark: 
````
mixins.py:147:5: E722 Do not use bare `except`
````
As it seems not super useful in my opinion to retrieved an exception not used afterwards 😄 
Cheers